### PR TITLE
Decrease tDW

### DIFF
--- a/src/AY3891x.cpp
+++ b/src/AY3891x.cpp
@@ -162,8 +162,10 @@ void AY3891x::write(byte regAddr, byte data) {
   daPinsOutput(data);
   // The Write Data Pulse Width tDW has a max time of 10 us per the datasheet
   // tDW = time that WRITE_DATA mode is enabled before going back to INACTIVE
-  setMode(WRITE_DATA);
-  setMode(INACTIVE_010);
+  if (_BDIR_pin != NO_PIN) {
+      digitalWrite(_BDIR_pin, HIGH);
+      digitalWrite(_BDIR_pin, LOW);
+  }
 //  setMode(INACTIVE_000);   // This is not needed since latchAddressMode() changes to 000
   daPinsInput();
 }


### PR DESCRIPTION
I've made this change so the signals comply with the timing specifications for tDW. I did this while trying to read/write unused bits in a YM2149F without success. It didn't help but I thought I would share it in case anyone needs a faster write.

I've been told the reading of unused bits might depend on the exact reference, YM2149F or YM2149G.

On Arduino Uno, tDW goes from 15.208us to 4.625us.